### PR TITLE
Parallelization of evaluation

### DIFF
--- a/config.py
+++ b/config.py
@@ -45,7 +45,7 @@ class CfgSensorsES:
     
     
 class CfgMnist:
-
+    eval_batch_size = 20
     batch_size = 128
     epochs = 10
     loss = 'categorical_crossentropy'

--- a/convindividual.py
+++ b/convindividual.py
@@ -1,8 +1,7 @@
 import random
 from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation, Flatten
-from keras.layers import Conv2D, MaxPooling2D
-from keras.optimizers import RMSprop
+from keras.layers import Conv2D, MaxPooling2D, InputLayer
 from utils import roulette 
 from individual import Layer
 from config import Config
@@ -75,38 +74,23 @@ class ConvIndividual:
             self.dense_layers.append(layer)
 
 
-    def createNetwork(self):
-
+    def createNetwork(self, input_layer=None):
         model = Sequential()
 
+        model.add(input_layer or InputLayer(Config.input_shape))
 
-        firstlayer = True
-
-        # convolutional part 
+        # convolutional part
         for l in self.conv_layers:
             if type(l) is ConvLayer:
-                if firstlayer:
-                    model.add(Conv2D(l.filters, (l.kernel_size, l.kernel_size),
-                                     padding='same', # let not the shape vanish
-                                     input_shape=self.input_shape))
-                    firstlayer = False
-                else:
-                    model.add(Conv2D(l.filters, (l.kernel_size, l.kernel_size), padding='same'))
+                model.add(Conv2D(l.filters, (l.kernel_size, l.kernel_size), padding='same'))
                 model.add(Activation(l.activation))
-                
             elif type(l) is MaxPoolLayer:
-                if firstlayer:
-                    model.add(MaxPooling2D(pool_size=(l.pool_size,l.pool_size),
-                                           input_shape=self.input_shape))
-                    firstlayer = False
-                else:
-                    # check if pooling is possible
-                    if model.layers[-1].output_shape[1] >= l.pool_size and model.layers[-1].output_shape[2] >= l.pool_size:
-                        model.add(MaxPooling2D(pool_size=(l.pool_size, l.pool_size)))
-                    
+                # check if pooling is possible
+                if model.output_shape[1] >= l.pool_size and model.output_shape[2] >= l.pool_size:
+                    model.add(MaxPooling2D(pool_size=(l.pool_size, l.pool_size)))
             else:
-                raise TypeError("unknown type of layer") 
-            
+                raise TypeError("unknown type of layer")
+
         # dense part
         model.add(Flatten())
         for l in self.dense_layers:
@@ -115,17 +99,14 @@ class ConvIndividual:
             if l.dropout > 0:
                 model.add(Dropout(l.dropout))
 
-        # final part 
+        # final part
         model.add(Dense(self.noutputs))
         if Config.task_type == "classification":
             model.add(Activation('softmax'))
-        
-        model.compile(loss=Config.loss,
-                      optimizer=RMSprop())
 
         self.nparams = model.count_params()
-                
-        return model 
+
+        return model
 
     
     def __str__(self):

--- a/fitness.py
+++ b/fitness.py
@@ -59,7 +59,7 @@ class Fitness:
 
             multi_model.fit(
                 X_train, [y_train] * len(individual_models),
-                batch_size=Config.batch_size, epochs=Config.epochs, verbose=1
+                batch_size=Config.batch_size, epochs=Config.epochs, verbose=0
             )
 
             pred_test = multi_model.predict(X_test)

--- a/fitness.py
+++ b/fitness.py
@@ -1,3 +1,4 @@
+import keras
 import random 
 import numpy as np 
 import pickle
@@ -27,7 +28,51 @@ class Fitness:
         
         # load train data 
         self.X, self.y = load_data(train_name)
-                
+
+    def evaluate_batch(self, individuals):
+        scores = []
+        kf = KFold(n_splits=5, random_state=42)
+        for train, test in kf.split(self.X):
+            X_train, X_test = self.X[train], self.X[test]
+            y_train, y_test = self.y[train], self.y[test]
+
+            input_features = keras.layers.InputLayer(Config.input_shape)
+            individual_models = [
+                individual.createNetwork(input_features)
+                for individual in individuals
+            ]
+            # TODO(proste) is it intended to effectively bin model sizes?
+            sizes = [(m.count_params() // 1000) for m in individual_models]
+
+            multi_model = keras.Model(
+                inputs=input_features.input,
+                outputs=[
+                    individual_model.output
+                    for individual_model in individual_models
+                ]
+            )
+            multi_model.compile(
+                loss=Config.loss,
+                optimizer=keras.optimizers.RMSprop()
+            )
+
+            multi_model.fit(
+                X_train, [y_train] * len(individual_models),
+                batch_size=Config.batch_size, epochs=Config.epochs, verbose=1
+            )
+
+            pred_test = multi_model.predict(X_test)
+            scores.append([
+                error(y_test, yy_test)
+                for yy_test in pred_test
+            ])
+
+        fitness = np.mean(scores, axis=0)
+
+        K.clear_session()  # free resources allocated by models
+
+        return list(zip(fitness, sizes))
+
     def evaluate(self, individual):
         #print(" *** evaluate *** ")
 

--- a/fitness.py
+++ b/fitness.py
@@ -51,32 +51,6 @@ class Fitness:
             # TODO(proste) is it intended to effectively bin model sizes?
             sizes = [(m.count_params() // 1000) for m in individual_models]
 
-
-            multi_model = keras.Model(
-                inputs=input_features.input,
-                outputs=[
-                    individual_model.output
-                    for individual_model in individual_models
-                ]
-            )
-            multi_model.compile(
-                loss=Config.loss,
-                optimizer=keras.optimizers.RMSprop()
-            )
-
-            multi_model.fit(
-                X_train, [y_train] * len(individual_models),
-                batch_size=Config.batch_size, epochs=Config.epochs, verbose=0
-            )
-
-            pred_test = multi_model.predict(X_test)
-            scores.append([
-                error(y_test, yy_test)
-                for yy_test in pred_test
-            ])
-
-            K.clear_session()  # free resources allocated by models
-
             xval_models.extend(individual_models)
 
         multi_model = keras.Model(
@@ -105,11 +79,11 @@ class Fitness:
 
         K.clear_session()  # free resources allocated by models
 
-
         fitness = np.mean(scores, axis=0)
 
         return list(zip(fitness, sizes))
 
+        
     def evaluate(self, individual):
         #print(" *** evaluate *** ")
 

--- a/fitness.py
+++ b/fitness.py
@@ -31,8 +31,7 @@ class Fitness:
 
     def evaluate_batch(self, individuals):
         scores = []
-        # TODO(proste) actually no shuffling takes places
-        kf = KFold(n_splits=5, random_state=42)
+        kf = KFold(n_splits=5, shuffle=True, random_state=42)
         for train, test in kf.split(self.X):
             X_train, X_test = self.X[train], self.X[test]
             y_train, y_test = self.y[train], self.y[test]

--- a/fitness.py
+++ b/fitness.py
@@ -73,7 +73,7 @@ class Fitness:
 
         pred_test = multi_model.predict(list(xval_datasets[:, 2]))
         scores = np.array([
-            error(xval_datasets[test_i % len(xval_datasets), 3], yy_test)
+            error(xval_datasets[test_i // len(individuals), 3], yy_test)
             for test_i, yy_test in enumerate(pred_test)
         ]).reshape(-1, len(individuals))
 

--- a/fitness.py
+++ b/fitness.py
@@ -3,6 +3,7 @@ import random
 import numpy as np 
 import pickle
 import sklearn
+import tqdm
 from sklearn.model_selection import KFold
 from dataset import load_data
 from config import Config
@@ -30,13 +31,19 @@ class Fitness:
         self.X, self.y = load_data(train_name)
 
     def evaluate_batch(self, individuals):
-        scores = []
         kf = KFold(n_splits=5, shuffle=True, random_state=42)
-        for train, test in kf.split(self.X):
-            X_train, X_test = self.X[train], self.X[test]
-            y_train, y_test = self.y[train], self.y[test]
+        xval_datasets = np.asarray([
+            (self.X[train], self.y[train], self.X[test], self.y[test])
+            for train, test in kf.split(self.X)
+        ], dtype=object)
 
-            input_features = keras.layers.InputLayer(Config.input_shape)
+        xval_features = [
+            keras.layers.InputLayer(Config.input_shape)
+            for _ in xval_datasets
+        ]
+
+        xval_models = []
+        for input_features in xval_features:
             individual_models = [
                 individual.createNetwork(input_features)
                 for individual in individuals
@@ -44,30 +51,33 @@ class Fitness:
             # TODO(proste) is it intended to effectively bin model sizes?
             sizes = [(m.count_params() // 1000) for m in individual_models]
 
-            multi_model = keras.Model(
-                inputs=input_features.input,
-                outputs=[
-                    individual_model.output
-                    for individual_model in individual_models
-                ]
-            )
-            multi_model.compile(
-                loss=Config.loss,
-                optimizer=keras.optimizers.RMSprop()
-            )
+            xval_models.extend(individual_models)
 
-            multi_model.fit(
-                X_train, [y_train] * len(individual_models),
-                batch_size=Config.batch_size, epochs=Config.epochs, verbose=1
-            )
+        multi_model = keras.Model(
+            inputs=[input_features.input for input_features in xval_features],
+            outputs=[
+                individual_model.output
+                for individual_model in xval_models
+            ]
+        )
+        multi_model.compile(
+            loss=Config.loss,
+            optimizer=keras.optimizers.RMSprop()
+        )
 
-            pred_test = multi_model.predict(X_test)
-            scores.append([
-                error(y_test, yy_test)
-                for yy_test in pred_test
-            ])
+        multi_model.fit(
+            list(xval_datasets[:, 0]),
+            [y_train for y_train in xval_datasets[:, 1] for _ in individuals],
+            batch_size=Config.batch_size, epochs=Config.epochs, verbose=1
+        )
 
-            K.clear_session()  # free resources allocated by models
+        pred_test = multi_model.predict(list(xval_datasets[:, 2]))
+        scores = np.array([
+            error(xval_datasets[test_i % len(xval_datasets), 3], yy_test)
+            for test_i, yy_test in enumerate(pred_test)
+        ]).reshape(-1, len(individuals))
+
+        K.clear_session()  # free resources allocated by models
 
         fitness = np.mean(scores, axis=0)
 

--- a/fitness.py
+++ b/fitness.py
@@ -8,6 +8,7 @@ from dataset import load_data
 from config import Config
 from utils import error
 from keras import backend as K 
+from tqdm import tqdm
 
 
 class Database:
@@ -30,13 +31,19 @@ class Fitness:
         self.X, self.y = load_data(train_name)
 
     def evaluate_batch(self, individuals):
-        scores = []
         kf = KFold(n_splits=5, shuffle=True, random_state=42)
-        for train, test in kf.split(self.X):
-            X_train, X_test = self.X[train], self.X[test]
-            y_train, y_test = self.y[train], self.y[test]
+        xval_datasets = np.asarray([
+            (self.X[train], self.y[train], self.X[test], self.y[test])
+            for train, test in kf.split(self.X)
+        ], dtype=object)
 
-            input_features = keras.layers.InputLayer(Config.input_shape)
+        xval_features = [
+            keras.layers.InputLayer(Config.input_shape)
+            for _ in xval_datasets
+        ]
+
+        xval_models = []
+        for input_features in tqdm(xval_features):
             individual_models = [
                 individual.createNetwork(input_features)
                 for individual in individuals
@@ -44,30 +51,33 @@ class Fitness:
             # TODO(proste) is it intended to effectively bin model sizes?
             sizes = [(m.count_params() // 1000) for m in individual_models]
 
-            multi_model = keras.Model(
-                inputs=input_features.input,
-                outputs=[
-                    individual_model.output
-                    for individual_model in individual_models
-                ]
-            )
-            multi_model.compile(
-                loss=Config.loss,
-                optimizer=keras.optimizers.RMSprop()
-            )
+            xval_models.extend(individual_models)
 
-            multi_model.fit(
-                X_train, [y_train] * len(individual_models),
-                batch_size=Config.batch_size, epochs=Config.epochs, verbose=1
-            )
+        multi_model = keras.Model(
+            inputs=[input_features.input for input_features in xval_features],
+            outputs=[
+                individual_model.output
+                for individual_model in xval_models
+            ]
+        )
+        multi_model.compile(
+            loss=Config.loss,
+            optimizer=keras.optimizers.RMSprop()
+        )
 
-            pred_test = multi_model.predict(X_test)
-            scores.append([
-                error(y_test, yy_test)
-                for yy_test in pred_test
-            ])
+        multi_model.fit(
+            list(xval_datasets[:, 0]),
+            [y_train for y_train in xval_datasets[:, 1] for _ in individuals],
+            batch_size=Config.batch_size, epochs=Config.epochs, verbose=1
+        )
 
-            K.clear_session()  # free resources allocated by models
+        pred_test = multi_model.predict(list(xval_datasets[:, 2]))
+        scores = np.array([
+            error(xval_datasets[test_i % len(xval_datasets), 3], yy_test)
+            for test_i, yy_test in enumerate(pred_test)
+        ]).reshape(-1, len(individuals))
+
+        K.clear_session()  # free resources allocated by models
 
         fitness = np.mean(scores, axis=0)
 

--- a/fitness.py
+++ b/fitness.py
@@ -31,6 +31,7 @@ class Fitness:
 
     def evaluate_batch(self, individuals):
         scores = []
+        # TODO(proste) actually no shuffling takes places
         kf = KFold(n_splits=5, random_state=42)
         for train, test in kf.split(self.X):
             X_train, X_test = self.X[train], self.X[test]
@@ -67,9 +68,9 @@ class Fitness:
                 for yy_test in pred_test
             ])
 
-        fitness = np.mean(scores, axis=0)
+            K.clear_session()  # free resources allocated by models
 
-        K.clear_session()  # free resources allocated by models
+        fitness = np.mean(scores, axis=0)
 
         return list(zip(fitness, sizes))
 

--- a/individual.py
+++ b/individual.py
@@ -1,7 +1,8 @@
 import random
 from keras.models import Sequential
 from keras.layers.core import Dense, Dropout, Activation
-from keras.optimizers import RMSprop
+from keras.layers import InputLayer 
+# from keras.optimizers import RMSprop
 
 from config import Config
 
@@ -40,17 +41,14 @@ class Individual:
             layer = Layer().randomInit() 
             self.layers.append(layer)
 
-    def createNetwork(self):
+    def createNetwork(self, input_layer=None):
 
         model = Sequential()
 
-        firstlayer = True
+        model.add(input_layer or InputLayer(Config.input_shape))
+
         for l in self.layers:
-            if firstlayer:
-                model.add(Dense(l.size, input_shape=self.input_shape))
-                firstlayer = False
-            else:
-                model.add(Dense(l.size))
+            model.add(Dense(l.size))
             model.add(Activation(l.activation))
             if l.dropout > 0:
                 model.add(Dropout(l.dropout))
@@ -60,8 +58,8 @@ class Individual:
         if Config.task_type == "classification":
             model.add(Activation('softmax'))
             
-        model.compile(loss=Config.loss,
-                      optimizer=RMSprop())
+        # model.compile(loss=Config.loss,
+        #               optimizer=RMSprop())
         
         return model 
 

--- a/main.py
+++ b/main.py
@@ -64,8 +64,8 @@ toolbox.register("individual", initIndividual, creator.Individual)
 toolbox.register("population", tools.initRepeat, list, toolbox.individual)
 
 # use multiple processors
-pool = multiprocessing.Pool(10)
-toolbox.register("map", pool.map)
+#pool = multiprocessing.Pool(10)
+#toolbox.register("map", pool.map)
 
 # register operators
 fit = Fitness("data/"+trainset_name)

--- a/main.py
+++ b/main.py
@@ -72,6 +72,7 @@ fit = Fitness("data/"+trainset_name)
 mut = MutationConv() if use_conv_layers else Mutation()
 cross = CrossoverConv() if use_conv_layers else Crossover()
 
+toolbox.register("eval_batch", fit.evaluate_batch)
 toolbox.register("evaluate", fit.evaluate)
 toolbox.register("mate", cross.cxOnePoint)
 toolbox.register("mutate", mut.mutate)


### PR DESCRIPTION
This is a draft implementation of parallel model training and prediction. The original functionality is preserved (at least hoped to be preserved).

- size of evaluation batch is to be set by configuration parameter `eval_batch_size`

Few things to consider
- dataset folds are kept the same for all trainings, the order of examples in epoch may change though (is this a problem?)
- size of gradient should be the same as in the original implementation (`multi_model` loss is sum of `individual_model`s losses - still this deserves to be well thought through

TODO
- [x] try on GPU and tune `eval_batch_size`
  - one epoch of `multi_model` training with `eval_batch_size = 20`  (currently the whole population) takes ~33s and ~2.5GiB of GPU memmory - this indicates that we may use bigger population with bearable time consumption